### PR TITLE
Bump crates base64-serde base64 clap pretty_env_logger rand lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-base64-serde = "0.3"
-base64 = "0.10"
+base64-serde = "0.6"
+base64 = "0.13"
 hyper = "0.12"
 hyper-tls = "0.3"
 tokio-timer = "0.2"
@@ -35,8 +35,8 @@ lazy_static = "1.3"
 tokio = { version = "0.1", optional = true }
 
 [dev-dependencies]
-clap = "2"
-pretty_env_logger = "0.3"
+clap = "3"
+pretty_env_logger = "0.4"
 tokio = "0.1"
-rand = "0.6"
-lazy_static = "1.3"
+rand = "0.8"
+lazy_static = "1.4"

--- a/README.md
+++ b/README.md
@@ -37,16 +37,6 @@ $ rustup default nightly
 $ rustup toolchain install nightly
 ```
 
-## CHANGES MADE SINCE FORKING
-1. README updates.
-2. Update the following Cargo packages to their latest.
-   1. base64-serde -> 0.6.1
-   2. base64 -> 0.13.0
-   3. clap -> 3
-   4. pretty_env_logger -> 0.4
-   5. rand -> 0.8
-   6. lazy_static -> 1.4
-
 ## Basic Usage
 
 ``` rust

--- a/README.md
+++ b/README.md
@@ -11,6 +11,42 @@ Goals:
 
 The crate is not yet tested on production so use at your own risk.
 
+## SETUP LOCAL RUST DEV ENV
+1. Install latest Rust via source & source Cargo env.
+```bash
+$ cd /tmp
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rust.sh
+$ vim rust.sh
+$ chmod u+x rust.sh
+$ ./rust.sh
+$ source $HOME/.cargo/env
+```
+
+2. Confirm Rust version & that we're up-to-date.
+```bash
+$ rustc --version
+$ rustup self update
+info: checking for self-updates
+info: downloading self-update
+  rustup updated - 1.25.1 (from 1.24.3)
+```
+
+3. Let's follow Rust Nightly & install Rust's nightly toolchain.
+``bash
+$ rustup default nightly
+$ rustup toolchain install nightly
+```
+
+## CHANGES MADE SINCE FORKING
+1. README updates.
+2. Update the following Cargo packages to their latest.
+   1. base64-serde -> 0.6.1
+   2. base64 -> 0.13.0
+   3. clap -> 3
+   4. pretty_env_logger -> 0.4
+   5. rand -> 0.8
+   6. lazy_static -> 1.4
+
 ## Basic Usage
 
 ``` rust


### PR DESCRIPTION
Bumped all the Cargo crates I could without triggering new **cargo build** errors.

Tested **cargo build** on the following:
```
rustc --version
rustc 1.66.0-nightly (9062b780b 2022-09-21)
```
Also: If you don't want the README updates I'll gladly remove.